### PR TITLE
When using optional Configurations, Exceptions might occur

### DIFF
--- a/src/ConfigurationService.Client/RemoteConfigurationProvider.cs
+++ b/src/ConfigurationService.Client/RemoteConfigurationProvider.cs
@@ -199,7 +199,7 @@ namespace ConfigurationService.Client
                 }
             }
 
-            return null;
+            return new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         }
 
         private string ComputeHash(Stream stream)


### PR DESCRIPTION
If a remote configuration is specified as optional, the internal data object of the RemoteConfigurationProvider might be
null. This can lead to Exceptions when trying to refer to the optional configuration.

If for instance compared to the local JSonConfigProvider, the data object is set to an empty dictionary instead of null.

Tested in a local setup with a self hosted config server instance.