### PR TITLE
fixed problem with differing path-separator characters

### DIFF
--- a/src/ConfigurationService.Hosting/ConfigurationService.Hosting.csproj
+++ b/src/ConfigurationService.Hosting/ConfigurationService.Hosting.csproj
@@ -6,7 +6,7 @@
       Configuration Service is a distributed configuration service for .NET.
     </Description>
     <TargetFramework>net6.0</TargetFramework>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Authors>James Pratt</Authors>
     <AssemblyName>ConfigurationService.Hosting</AssemblyName>
     <PackageId>ConfigurationService.Hosting</PackageId>

--- a/src/ConfigurationService.Hosting/Extensions/StringExtensions.cs
+++ b/src/ConfigurationService.Hosting/Extensions/StringExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System.IO;
+
+namespace ConfigurationService.Hosting.Extensions
+{
+    public static class StringExtensions
+    {
+
+        public static string NormalizePathSeparators(this string path)
+        {
+            return path.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+        }
+
+    }
+}

--- a/src/ConfigurationService.Hosting/Providers/Git/GitProvider.cs
+++ b/src/ConfigurationService.Hosting/Providers/Git/GitProvider.cs
@@ -4,6 +4,8 @@ using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using ConfigurationService.Hosting.Extensions;
+
 using LibGit2Sharp;
 using LibGit2Sharp.Handlers;
 using Microsoft.Extensions.Logging;
@@ -158,7 +160,7 @@ namespace ConfigurationService.Hosting.Providers.Git
 
                 foreach (var entry in repo.Index)
                 {
-                    files.Add(entry.Path);
+                    files.Add(entry.Path.NormalizePathSeparators());
                 }
             }
 
@@ -187,7 +189,7 @@ namespace ConfigurationService.Hosting.Providers.Git
                     if (entry.Exists)
                     {
                         _logger.LogInformation("File {Path} changed.", entry.Path);
-                        changedFiles.Add(entry.Path);
+                        changedFiles.Add(entry.Path.NormalizePathSeparators());
                     }
                     else
                     {
@@ -281,7 +283,7 @@ namespace ConfigurationService.Hosting.Providers.Git
 
         private string GetRelativePath(string fullPath)
         {
-            return Path.GetRelativePath(_providerOptions.LocalPath, fullPath);
+            return Path.GetRelativePath(_providerOptions.LocalPath, fullPath).NormalizePathSeparators();
         }
     }
 }


### PR DESCRIPTION
File-changes were not detected in the Git provider, because paths differed in their path-separator chacters.