### PR TITLE
[FixUriPathPattern] 'added wildcard pattern for config file names'

### DIFF
--- a/src/ConfigurationService.Hosting/ConfigurationEndpointRouteBuilderExtensions.cs
+++ b/src/ConfigurationService.Hosting/ConfigurationEndpointRouteBuilderExtensions.cs
@@ -1,13 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Net;
-using System.Text;
-using System.Text.Json;
-using ConfigurationService.Hosting.Providers;
+﻿using ConfigurationService.Hosting.Providers;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using System.Text.Json;
 
 namespace ConfigurationService.Hosting;
 
@@ -58,16 +58,16 @@ public static class ConfigurationEndpointRouteBuilderExtensions
     {
         var provider = endpointRouteBuilder.ServiceProvider.GetService<IProvider>();
 
-        return endpointRouteBuilder.MapGet(pattern + "/{name}", async context =>
+        return endpointRouteBuilder.MapGet(pattern + "/{*name}", async context =>
         {
-            var name = context.GetRouteValue("name")?.ToString();
+            var name = context.Request.Path.ToString().Substring(pattern.Length);
             name = WebUtility.UrlDecode(name);
 
             var bytes = await provider.GetConfiguration(name);
 
             if (bytes == null)
             {
-                context.Response.StatusCode = 404;
+                context.Response.StatusCode = (int)HttpStatusCode.NotFound;
                 return;
             }
 

--- a/src/ConfigurationService.Hosting/Providers/Git/GitProvider.cs
+++ b/src/ConfigurationService.Hosting/Providers/Git/GitProvider.cs
@@ -1,14 +1,13 @@
-﻿using System;
+﻿using ConfigurationService.Hosting.Extensions;
+using LibGit2Sharp;
+using LibGit2Sharp.Handlers;
+using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using ConfigurationService.Hosting.Extensions;
-
-using LibGit2Sharp;
-using LibGit2Sharp.Handlers;
-using Microsoft.Extensions.Logging;
 
 namespace ConfigurationService.Hosting.Providers.Git;
 
@@ -131,6 +130,16 @@ public class GitProvider : IProvider
 
     public async Task<byte[]> GetConfiguration(string name)
     {
+        if (string.IsNullOrEmpty(name))
+        {
+            return null;
+        }
+
+        if (name.StartsWith('/'))
+        {
+            name = name.Substring(1);
+        }
+
         string path = Path.Combine(_providerOptions.LocalPath, name);
 
         if (!File.Exists(path))


### PR DESCRIPTION
Fixed the problem with config files that were not accessible via REST interface when they were located in a subfolder, because of the URI pattern used to bind the route of the REST service.